### PR TITLE
owner,scheduler(cdc): fix nil pointer panic in owner scheduler (#2980)

### DIFF
--- a/cdc/owner/scheduler_v1.go
+++ b/cdc/owner/scheduler_v1.go
@@ -309,6 +309,11 @@ func (s *oldScheduler) handleJobs(jobs []*schedulerJob) {
 func (s *oldScheduler) cleanUpFinishedOperations() {
 	for captureID := range s.state.TaskStatuses {
 		s.state.PatchTaskStatus(captureID, func(status *model.TaskStatus) (*model.TaskStatus, bool, error) {
+			if status == nil {
+				log.Warn("task status of the capture is not found, may be the key in etcd was deleted.")
+				return status, false, nil
+			}
+
 			changed := false
 			for tableID, operation := range status.Operation {
 				if operation.Status == model.OperFinished {

--- a/cdc/owner/scheduler_v1_test.go
+++ b/cdc/owner/scheduler_v1_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/pkg/etcd"
 	"github.com/pingcap/tiflow/pkg/orchestrator"
 	"github.com/pingcap/tiflow/pkg/util/testleak"
 )
@@ -83,8 +84,24 @@ func (s *schedulerSuite) finishTableOperation(captureID model.CaptureID, tableID
 
 func (s *schedulerSuite) TestScheduleOneCapture(c *check.C) {
 	defer testleak.AfterTest(c)()
+
 	s.reset(c)
-	captureID := "test-capture-1"
+	captureID := "test-capture-0"
+	s.addCapture(captureID)
+
+	_, _ = s.scheduler.Tick(s.state, []model.TableID{}, s.captures)
+
+	// Manually simulate the scenario where the corresponding key was deleted in the etcd
+	key := &etcd.CDCKey{
+		Tp:           etcd.CDCKeyTypeTaskStatus,
+		CaptureID:    captureID,
+		ChangefeedID: s.state.ID,
+	}
+	s.tester.MustUpdate(key.String(), nil)
+	s.tester.MustApplyPatches()
+
+	s.reset(c)
+	captureID = "test-capture-1"
 	s.addCapture(captureID)
 
 	// add three tables


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #2980

### What is changed and how it works?


Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix nil pointer panic encountered when scheduler cleanup finished operations 
```
