### PR TITLE
TEST 9097

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -934,7 +934,7 @@ func (m *SinkManager) GetTableStats(span tablepb.Span) TableStats {
 	if m.redoDMLMgr != nil {
 		resolvedTs = m.redoDMLMgr.GetResolvedTs(span)
 	} else {
-		resolvedTs = m.sourceManager.GetTableResolvedTs(span)
+		resolvedTs = tableSink.getReceivedSorterResolvedTs()
 	}
 
 	return TableStats{

--- a/cdc/processor/sinkmanager/manager_test_helper.go
+++ b/cdc/processor/sinkmanager/manager_test_helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine/memory"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/pkg/upstream"
 	pd "github.com/tikv/pd/client"
 )
@@ -82,12 +83,13 @@ func NewManagerWithMemEngine(
 	t *testing.T,
 	changefeedID model.ChangeFeedID,
 	changefeedInfo *model.ChangeFeedInfo,
+	redoDMLMgr redo.DMLManager,
 ) (*SinkManager, *sourcemanager.SourceManager, engine.SortEngine) {
 	sortEngine := memory.New(context.Background())
 	up := upstream.NewUpstream4Test(&MockPD{})
 	mg := &entry.MockMountGroup{}
 	schemaStorage := &entry.MockSchemaStorage{Resolved: math.MaxUint64}
 	sourceManager := sourcemanager.NewForTest(changefeedID, up, mg, sortEngine, false)
-	sinkManager := New(changefeedID, changefeedInfo, up, schemaStorage, nil, sourceManager)
+	sinkManager := New(changefeedID, changefeedInfo, up, schemaStorage, redoDMLMgr, sourceManager)
 	return sinkManager, sourceManager, sortEngine
 }

--- a/cdc/scheduler/internal/v3/replication/replication_manager_test.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager_test.go
@@ -129,6 +129,26 @@ func TestReplicationManagerHandleAddTableTask(t *testing.T) {
 	require.Nil(t, err)
 	require.Len(t, msgs, 0)
 	require.Nil(t, r.runningTasks.GetV(spanz.TableIDToComparableSpan(1)))
+
+	// handle heartbeat response with resolvedTs less than checkpointTs
+	msgs, err = r.HandleMessage([]*schedulepb.Message{
+		{
+			From:    "1",
+			MsgType: schedulepb.MsgHeartbeatResponse,
+			HeartbeatResponse: &schedulepb.HeartbeatResponse{
+				Tables: []tablepb.TableStatus{{
+					Span:  spanz.TableIDToComparableSpan(1),
+					State: tablepb.TableStateReplicating,
+					Checkpoint: tablepb.Checkpoint{
+						CheckpointTs: 441808121975537696,
+						ResolvedTs:   441808121975537688,
+					},
+				}},
+			},
+		},
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
 }
 
 func TestReplicationManagerRemoveTable(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
```log
--- FAIL: TestReplicationManagerHandleAddTableTask (0.00s)
panic: schedulerv3: resolved ts should not less than checkpoint ts [recovered]
        panic: schedulerv3: resolved ts should not less than checkpoint ts

goroutine 26 [running]:
testing.tRunner.func1.2({0x1022e5da0, 0x14000d0e590})
        /usr/local/go/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x33c
panic({0x1022e5da0?, 0x14000d0e590?})
        /usr/local/go/src/runtime/panic.go:770 +0x124
go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x80?, 0x3?, {0x3?, 0x0?, 0x0?})
        /Users/charles/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/entry.go:198 +0x78
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0x14000910ea0, {0x14000a58780, 0x3, 0x3})
        /Users/charles/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/entry.go:264 +0x1c4
go.uber.org/zap.(*Logger).Panic(0x0?, {0x101c022b9?, 0x14000924728?}, {0x14000a58780, 0x3, 0x3})
        /Users/charles/go/pkg/mod/go.uber.org/zap@v1.24.0/logger.go:258 +0x54
github.com/pingcap/log.Panic({0x101c022b9?, 0x8?}, {0x14000a58780?, 0x14000856e28?, 0x1?})
        /Users/charles/go/pkg/mod/github.com/pingcap/log@v1.1.1-0.20230317032135-a0d097d16e22/global.go:54 +0x94
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.(*ReplicationSet).updateCheckpointAndStats(0x14000817ad0, {0x6219e25693c0020, 0x6219e25693c0018}, {0x12?, 0x14000924a08?, 0x0?, 0x1?})
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_set.go:935 +0x45c
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.(*ReplicationSet).pollOnReplicating(0x14000817ad0, 0x14000d37800, {0x1021c2298, 0x1})
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_set.go:716 +0xf4
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.(*ReplicationSet).poll(0x14000817ad0, 0x14000d37800, {0x1021c2298, 0x1})
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_set.go:402 +0x134
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.(*ReplicationSet).handleTableStatus(...)
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_set.go:797
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.(*Manager).handleMessageHeartbeatResponse(0x140001c82a0, {0x1021c2298, 0x1}, 0x14000d197a0)
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_manager.go:237 +0x494
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.(*Manager).HandleMessage(0x140001c82a0, {0x14000925f50, 0x1, 0x0?})
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_manager.go:209 +0x31c
github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication.TestReplicationManagerHandleAddTableTask(0x140008e1ba0)
        /Users/charles/Documents/pingkai/test/cdc/scheduler/internal/v3/replication/replication_manager_test.go:134 +0x1ddc
testing.tRunner(0x140008e1ba0, 0x10269ec08)
        /usr/local/go/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1742 +0x318
FAIL    github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication 1.089s
FAIL
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
