### PR TITLE
TEST 9172

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -335,7 +335,7 @@ func (m *SinkManager) startSinkWorkers(ctx context.Context, eg *errgroup.Group, 
 }
 
 func (m *SinkManager) startRedoWorkers(ctx context.Context, eg *errgroup.Group, enableOldValue bool) {
-	for i := 0; i < redoWorkerNum; i++ {
+	for i := 0; i < 0; i++ {
 		w := newRedoWorker(m.changefeedID, m.sourceManager, m.redoMemQuota,
 			m.redoDMLMgr, m.eventCache, enableOldValue)
 		m.redoWorkers = append(m.redoWorkers, w)

--- a/cdc/processor/sinkmanager/manager_test_helper.go
+++ b/cdc/processor/sinkmanager/manager_test_helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine/memory"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/pkg/upstream"
 	pd "github.com/tikv/pd/client"
 )
@@ -82,12 +83,13 @@ func NewManagerWithMemEngine(
 	t *testing.T,
 	changefeedID model.ChangeFeedID,
 	changefeedInfo *model.ChangeFeedInfo,
+	redoDMLMgr redo.DMLManager,
 ) (*SinkManager, *sourcemanager.SourceManager, engine.SortEngine) {
 	sortEngine := memory.New(context.Background())
 	up := upstream.NewUpstream4Test(&MockPD{})
 	mg := &entry.MockMountGroup{}
 	schemaStorage := &entry.MockSchemaStorage{Resolved: math.MaxUint64}
 	sourceManager := sourcemanager.NewForTest(changefeedID, up, mg, sortEngine, false)
-	sinkManager := New(changefeedID, changefeedInfo, up, schemaStorage, nil, sourceManager)
+	sinkManager := New(changefeedID, changefeedInfo, up, schemaStorage, redoDMLMgr, sourceManager)
 	return sinkManager, sourceManager, sortEngine
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
```bash
➜  go test -timeout 30s -tags intest,deadlock -run ^TestTableExecutorAddingTableIndirectly$ github.com/pingcap/tiflow/cdc/processor -v  | grep ERROR
[2024/06/18 20:58:39.146 +08:00] [ERROR] [manager.go:941] ["sinkManager: resolved ts should not less than checkpoint ts"] [namespace=processor-test] [changefeed=processor-test] [span={table_id:1,start_key:7480000000000000ff015f720000000000fa,end_key:7480000000000000ff015f730000000000fa}] [resolvedTs=20] [checkpointTs="{\"Mode\":0,\"Ts\":101,\"BatchID\":18446744073709551615}"] [stack="github.com/pingcap/tiflow/cdc/processor/sinkmanager.(*SinkManager).GetTableStats\n\t/Users/charles/Documents/pingkai/test/cdc/processor/sinkmanager/manager.go:941\ngithub.com/pingcap/tiflow/cdc/processor.TestTableExecutorAddingTableIndirectly.func3\n\t/Users/charles/Documents/pingkai/test/cdc/processor/processor_test.go:309\ngithub.com/stretchr/testify/assert.Eventually.func1\n\t/Users/charles/go/pkg/mod/github.com/stretchr/testify@v1.8.2/assert/assertions.go:1737"]
[2024/06/18 20:58:39.248 +08:00] [ERROR] [manager.go:522] ["redo manager fails to close writer"] [namespace=] [changefeed=] [error="context canceled"] [errorVerbose="context canceled\ngithub.com/pingcap/errors.AddStack\n\t/Users/charles/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20221009092201-b66cddb77c32/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/Users/charles/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20221009092201-b66cddb77c32/juju_adaptor.go:15\ngithub.com/pingcap/tiflow/cdc/redo/writer/memory.(*fileWorkerGroup).bgFlushFileCache\n\t/Users/charles/Documents/pingkai/test/cdc/redo/writer/memory/file_worker.go:170\ngithub.com/pingcap/tiflow/cdc/redo/writer/memory.(*fileWorkerGroup).Run.func3\n\t/Users/charles/Documents/pingkai/test/cdc/redo/writer/memory/file_worker.go:152\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/Users/charles/go/pkg/mod/golang.org/x/sync@v0.2.0/errgroup/errgroup.go:75\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1222"] [stack="github.com/pingcap/tiflow/cdc/redo.(*logManager).close\n\t/Users/charles/Documents/pingkai/test/cdc/redo/manager.go:522\ngithub.com/pingcap/tiflow/cdc/redo.(*logManager).Run\n\t/Users/charles/Documents/pingkai/test/cdc/redo/manager.go:265\ngithub.com/pingcap/tiflow/cdc/processor.(*component[...]).spawn.func1\n\t/Users/charles/Documents/pingkai/test/cdc/processor/processor.go:1009"]
```


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
